### PR TITLE
Fix vertical dpi scaling in PdfDocumentPaginator.cs

### DIFF
--- a/Print/PdfDocumentPaginator.cs
+++ b/Print/PdfDocumentPaginator.cs
@@ -204,7 +204,7 @@ namespace Patagames.Pdf.Net.Controls.Wpf
 					b2.Dispose();
 
 				var dc = visual.RenderOpen();
-				dc.DrawImage(imgsrc, new Rect(0, 0, imgsrc.PixelWidth / (dpiX / 96.0), imgsrc.Height / (dpiY / 90.0)));
+				dc.DrawImage(imgsrc, new Rect(0, 0, imgsrc.PixelWidth / (dpiX / 96.0), imgsrc.Height / (dpiY / 96.0)));
 				dc.Close();
 				imgsrc = null;
 			}


### PR DESCRIPTION
The value used to divide dpiY when calling DrawImage inside of RenderPage was incorrectly set to 90.0 instead of 96.0. This caused the printed result to be squished vertically.